### PR TITLE
fix: wire login page through content script message bridge

### DIFF
--- a/bridge/handlers/verify.go
+++ b/bridge/handlers/verify.go
@@ -92,8 +92,11 @@ func HandleVerify(store *ChallengeStore, oidcStore *storage.Storage, usersJSON s
 			return
 		}
 
-		sigStr := string(sigRaw)
-		sigStr = sigStr[1 : len(sigStr)-1]
+		var sigStr string
+		if err := json.Unmarshal(sigRaw, &sigStr); err != nil {
+			http.Error(w, "invalid signature encoding", http.StatusBadRequest)
+			return
+		}
 
 		if err := crypto.VerifyCozSignature(payBytes, sigStr, user.PublicKey); err != nil {
 			log.Printf("Coz signature verification failed: %v", err)

--- a/bridge/templates/login.html
+++ b/bridge/templates/login.html
@@ -107,6 +107,33 @@
     <script>
         const authRequestID = '{{.AuthRequestID}}';
         let currentNonce = '';
+        let extensionReady = false;
+
+        // Listen for messages from the content script
+        window.addEventListener('message', (event) => {
+            if (!event.data || event.data.source !== 'cyphrmask') return;
+
+            if (event.data.type === 'EXTENSION_STATUS') {
+                const status = event.data.status;
+                if (status && status.wasmReady) {
+                    extensionReady = true;
+                    const btn = document.getElementById('sign-btn');
+                    btn.disabled = false;
+                    btn.textContent = 'Sign In with CyphrMask';
+                }
+            }
+
+            if (event.data.type === 'SIGNATURE_RESPONSE') {
+                submitCoz(event.data.coz);
+            }
+
+            if (event.data.type === 'SIGNATURE_ERROR') {
+                showStatus('Error: ' + (event.data.error || 'Unknown error'), 'error');
+                const btn = document.getElementById('sign-btn');
+                btn.disabled = false;
+                btn.textContent = 'Try Again';
+            }
+        });
 
         async function fetchChallenge() {
             try {
@@ -115,51 +142,22 @@
                 const data = await resp.json();
                 currentNonce = data.nonce;
                 document.getElementById('nonce-display').textContent = data.nonce.substring(0, 32) + '...';
-                await checkExtension();
             } catch (err) {
                 showStatus('Failed to load challenge: ' + err.message, 'error');
             }
         }
 
-        async function checkExtension() {
-            try {
-                const resp = await chrome.runtime.sendMessage(
-                    { action: 'PING' }
-                ).catch(() => null);
-
-                if (resp && resp.status === 'ready') {
-                    const btn = document.getElementById('sign-btn');
-                    btn.disabled = false;
-                    btn.textContent = 'Sign In with CyphrMask';
-                } else {
-                    showStatus('Waiting for CyphrMask extension...', 'loading');
-                }
-            } catch {
-                showStatus('Waiting for CyphrMask extension...', 'loading');
-            }
-        }
-
-        document.getElementById('sign-btn').addEventListener('click', async () => {
+        document.getElementById('sign-btn').addEventListener('click', () => {
             const btn = document.getElementById('sign-btn');
             btn.disabled = true;
             btn.textContent = 'Requesting signature...';
             showStatus('Waiting for your approval in CyphrMask...', 'loading');
 
-            try {
-                const resp = await chrome.runtime.sendMessage(
-                    { action: 'REQUEST_SIGNATURE', nonce: currentNonce }
-                );
-
-                if (resp && resp.coz) {
-                    await submitCoz(resp.coz);
-                } else {
-                    throw new Error(resp?.error || 'Signature request failed');
-                }
-            } catch (err) {
-                showStatus('Error: ' + err.message, 'error');
-                btn.disabled = false;
-                btn.textContent = 'Try Again';
-            }
+            window.postMessage({
+                source: 'cyphrmask-bridge',
+                type: 'REQUEST_SIGNATURE',
+                nonce: currentNonce
+            }, '*');
         });
 
         async function submitCoz(cozString) {

--- a/bridge/templates/login.html
+++ b/bridge/templates/login.html
@@ -107,7 +107,6 @@
     <script>
         const authRequestID = '{{.AuthRequestID}}';
         let currentNonce = '';
-        let extensionReady = false;
 
         // Listen for messages from the content script
         window.addEventListener('message', (event) => {
@@ -116,7 +115,6 @@
             if (event.data.type === 'EXTENSION_STATUS') {
                 const status = event.data.status;
                 if (status && status.wasmReady) {
-                    extensionReady = true;
                     const btn = document.getElementById('sign-btn');
                     btn.disabled = false;
                     btn.textContent = 'Sign In with CyphrMask';

--- a/cyphrmask/src/background.js
+++ b/cyphrmask/src/background.js
@@ -11,7 +11,8 @@ let wasmInitError = null;
 // Initialize Wasm module on startup
 (async () => {
   try {
-    await wasmModule();
+    const wasmUrl = chrome.runtime.getURL('wasm/cyphr_crypto_bg.wasm');
+    await wasmModule(wasmUrl);
     wasmReady = true;
     console.log('[CyphrMask] Wasm crypto module initialized');
   } catch (err) {


### PR DESCRIPTION
**Login page now talks to the extension through the content script's
postMessage bridge** instead of calling `chrome.runtime.sendMessage`
directly — which failed because login.html is a regular web page, not
an extension context where that API exists.

The sign button enable flow and signature request path both go through
`window.postMessage` → content script → background worker → response
back via `postMessage`. The content script was already set up for this;
the page just wasn't using it.

Three fixes in total:

- **`bridge/templates/login.html`** — Replaced `chrome.runtime.sendMessage`
  calls with `window.postMessage` to the content script. Listens for
  `EXTENSION_STATUS` to detect when wasm is ready, and
  `SIGNATURE_RESPONSE`/`SIGNATURE_ERROR` for the result.

- **`cyphrmask/src/background.js`** — Passes an explicit
  `chrome.runtime.getURL()` path to the wasm module instead of relying
  on `import.meta.url` fallback in the service worker context.

- **`bridge/handlers/verify.go`** — Replaces fragile string slicing
  (`sigStr[1:len-1]` to strip JSON quotes) with proper `json.Unmarshal`.
  *The old approach would break if the signature contained escaped
  quotes or if the JSON encoder changed its output format.*