### PR TITLE
fix: complete OIDC auth flow — options page, login bridge, and callback handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,8 @@ BRIDGE_SIGNING_KEY_PATH=/keys/signing-key.pem
 # Registered users (JSON map of thumbprint -> {email, public_key})
 # Copy from extension's "Copy Bridge User JSON" button.
 # Public key can be uncompressed hex (04+X+Y), PEM, or base64.
-# BRIDGE_USERS={"<thumbprint>":{"email":"user@example.com","public_key":"04..."}}
+# Single quotes required for .env — the extension copies the full line.
+# BRIDGE_USERS='{"<thumbprint>":{"email":"user@example.com","public_key":"04..."}}'
 BRIDGE_USERS=
 
 # Registered OIDC clients (JSON array of {id, secret, redirect_uris})

--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,9 @@ BRIDGE_CALLBACK_URL=http://localhost:8080/callback
 BRIDGE_SIGNING_KEY_PATH=/keys/signing-key.pem
 
 # Registered users (JSON map of thumbprint -> {email, public_key})
-# Overrides the default test user. Format:
-# BRIDGE_USERS={"<thumbprint>":{"email":"user@example.com","public_key":"-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"}}
+# Copy from extension's "Copy Bridge User JSON" button.
+# Public key can be uncompressed hex (04+X+Y), PEM, or base64.
+# BRIDGE_USERS={"<thumbprint>":{"email":"user@example.com","public_key":"04..."}}
 BRIDGE_USERS=
 
 # Registered OIDC clients (JSON array of {id, secret, redirect_uris})

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ result-*
 docker-data/
 *.log
 keys/
-.keys/
+bridge/.keys/
 
 # Env files (keep .env.example)
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ result-*
 docker-data/
 *.log
 keys/
+.keys/
 
 # Env files (keep .env.example)
 .env

--- a/bridge/handlers/callback.go
+++ b/bridge/handlers/callback.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/ic4y/cyphrmask-oidc-poc/bridge/storage"
+)
+
+// CallbackHandler handles the redirect after successful Coz verification.
+// It creates an authorization code and redirects to the client's redirect_uri.
+type CallbackHandler struct {
+	store *storage.Storage
+}
+
+func NewCallbackHandler(store *storage.Storage) *CallbackHandler {
+	return &CallbackHandler{store: store}
+}
+
+func (h *CallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	authReqID := r.URL.Query().Get("id")
+	if authReqID == "" {
+		http.Error(w, "missing auth request id", http.StatusBadRequest)
+		return
+	}
+
+	req, err := h.store.AuthRequestByID(r.Context(), authReqID)
+	if err != nil {
+		log.Printf("callback handler: auth request not found: %v", err)
+		http.Error(w, "invalid auth request", http.StatusBadRequest)
+		return
+	}
+
+	// Create the authorization code
+	code := genCode()
+	if err := h.store.SaveAuthCode(r.Context(), authReqID, code); err != nil {
+		log.Printf("callback handler: failed to save auth code: %v", err)
+		http.Error(w, "failed to create authorization code", http.StatusInternalServerError)
+		return
+	}
+
+	// Redirect to client's redirect_uri with the code
+	redirectURL := fmt.Sprintf("%s?code=%s&state=%s", req.GetRedirectURI(), code, req.GetState())
+	log.Printf("callback handler: redirecting to %s", req.GetRedirectURI())
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+func genCode() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return base64.RawURLEncoding.EncodeToString(b)
+}

--- a/bridge/handlers/login.go
+++ b/bridge/handlers/login.go
@@ -29,7 +29,6 @@ func (h *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Look up the auth request to get the client info
 	req, err := h.store.AuthRequestByID(r.Context(), authReqID)
 	if err != nil {
 		log.Printf("login handler: auth request not found: %v", err)
@@ -41,10 +40,14 @@ func (h *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		AuthRequestID string
 		ClientID      string
 		Issuer        string
+		RedirectURI   string
+		State         string
 	}{
 		AuthRequestID: authReqID,
 		ClientID:      req.GetClientID(),
 		Issuer:        h.issuer,
+		RedirectURI:   req.GetRedirectURI(),
+		State:         req.GetState(),
 	}
 
 	w.Header().Set("Content-Type", "text/html")

--- a/bridge/handlers/token_callback.go
+++ b/bridge/handlers/token_callback.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/ic4y/cyphrmask-oidc-poc/bridge/storage"
+)
+
+// TokenCallbackHandler handles the client's redirect_uri after authorization code is issued.
+// In a full OIDC flow, the client would exchange the code for tokens here.
+// For this PoC, we just show success.
+type TokenCallbackHandler struct {
+	store *storage.Storage
+}
+
+func NewTokenCallbackHandler(store *storage.Storage) *TokenCallbackHandler {
+	return &TokenCallbackHandler{store: store}
+}
+
+func (h *TokenCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	code := r.URL.Query().Get("code")
+	state := r.URL.Query().Get("state")
+
+	if code == "" {
+		http.Error(w, "missing authorization code", http.StatusBadRequest)
+		return
+	}
+
+	// Look up the auth request to show user info
+	req, err := h.store.AuthRequestByCode(r.Context(), code)
+	if err != nil {
+		log.Printf("token callback: invalid code: %v", err)
+		http.Error(w, "invalid or expired code", http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(`<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Sign In Complete</title>
+<style>
+body { background: #0f172a; color: #e2e8f0; font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+.container { background: #1e293b; border-radius: 12px; padding: 2rem; max-width: 480px; width: 100%; box-shadow: 0 4px 24px rgba(0,0,0,0.4); text-align: center; }
+h1 { color: #22c55e; margin: 0 0 1rem; }
+p { color: #94a3b8; }
+code { background: #0f172a; padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.85rem; }
+</style></head><body>
+<div class="container">
+<h1>Authentication Successful</h1>
+<p>You have been authenticated via Cyphr-OIDC Bridge.</p>
+<p>Subject: <code>` + req.GetSubject() + `</code></p>
+<p>State: <code>` + state + `</code></p>
+</div></body></html>`))
+}

--- a/bridge/handlers/verify.go
+++ b/bridge/handlers/verify.go
@@ -92,8 +92,11 @@ func HandleVerify(store *ChallengeStore, oidcStore *storage.Storage, usersJSON s
 			return
 		}
 
-		sigStr := string(sigRaw)
-		sigStr = sigStr[1 : len(sigStr)-1]
+		var sigStr string
+		if err := json.Unmarshal(sigRaw, &sigStr); err != nil {
+			http.Error(w, "invalid signature encoding", http.StatusBadRequest)
+			return
+		}
 
 		if err := crypto.VerifyCozSignature(payBytes, sigStr, user.PublicKey); err != nil {
 			log.Printf("Coz signature verification failed: %v", err)

--- a/bridge/handlers/verify.go
+++ b/bridge/handlers/verify.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"crypto/sha256"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -86,11 +85,8 @@ func HandleVerify(store *ChallengeStore, oidcStore *storage.Storage, usersJSON s
 		store.Delete(sessionID)
 
 		payBytes := []byte(payRaw)
-		hash := sha256.Sum256(payBytes)
-		log.Printf("verify: payHash=%x payBytes=%q (len=%d)", hash[:], string(payBytes), len(payBytes))
 
 		user, ok := users[pay.Tmb]
-		log.Printf("verify: thumbprint=%q found=%v publicKey=%q", pay.Tmb, ok, user.PublicKey)
 		if !ok {
 			http.Error(w, "unknown key thumbprint", http.StatusUnauthorized)
 			return
@@ -101,7 +97,6 @@ func HandleVerify(store *ChallengeStore, oidcStore *storage.Storage, usersJSON s
 			http.Error(w, "invalid signature encoding", http.StatusBadRequest)
 			return
 		}
-		log.Printf("verify: sig=%q (len=%d)", sigStr, len(sigStr))
 
 		if err := crypto.VerifyCozSignature(payBytes, sigStr, user.PublicKey); err != nil {
 			log.Printf("Coz signature verification failed: %v", err)

--- a/bridge/handlers/verify.go
+++ b/bridge/handlers/verify.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -85,6 +86,8 @@ func HandleVerify(store *ChallengeStore, oidcStore *storage.Storage, usersJSON s
 		store.Delete(sessionID)
 
 		payBytes := []byte(payRaw)
+		hash := sha256.Sum256(payBytes)
+		log.Printf("verify: payHash=%x payBytes=%q (len=%d)", hash[:], string(payBytes), len(payBytes))
 
 		user, ok := users[pay.Tmb]
 		log.Printf("verify: thumbprint=%q found=%v publicKey=%q", pay.Tmb, ok, user.PublicKey)
@@ -98,6 +101,7 @@ func HandleVerify(store *ChallengeStore, oidcStore *storage.Storage, usersJSON s
 			http.Error(w, "invalid signature encoding", http.StatusBadRequest)
 			return
 		}
+		log.Printf("verify: sig=%q (len=%d)", sigStr, len(sigStr))
 
 		if err := crypto.VerifyCozSignature(payBytes, sigStr, user.PublicKey); err != nil {
 			log.Printf("Coz signature verification failed: %v", err)

--- a/bridge/handlers/verify.go
+++ b/bridge/handlers/verify.go
@@ -87,6 +87,7 @@ func HandleVerify(store *ChallengeStore, oidcStore *storage.Storage, usersJSON s
 		payBytes := []byte(payRaw)
 
 		user, ok := users[pay.Tmb]
+		log.Printf("verify: thumbprint=%q found=%v publicKey=%q", pay.Tmb, ok, user.PublicKey)
 		if !ok {
 			http.Error(w, "unknown key thumbprint", http.StatusUnauthorized)
 			return

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -62,7 +62,8 @@ func main() {
 
 	router.Mount("/", http.Handler(provider))
 	router.Handle("/login", loginHandler)
-	router.HandleFunc("/login/callback", op.AuthorizeCallbackHandler(provider))
+	router.Handle("/login/callback", handlers.NewCallbackHandler(oidcStore))
+	router.Handle("/callback", handlers.NewTokenCallbackHandler(oidcStore))
 	router.HandleFunc("GET /api/challenge", handlers.HandleChallenge(challengeStore))
 	router.HandleFunc("POST /api/verify", handlers.HandleVerify(challengeStore, oidcStore, cfg.Users))
 	router.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {

--- a/bridge/storage/storage.go
+++ b/bridge/storage/storage.go
@@ -636,6 +636,6 @@ func loadOrGenerateKey(path string) (*rsa.PrivateKey, error) {
 
 // TestUser is a PoC user with their public key and email.
 type TestUser struct {
-	PublicKey string
-	Email     string
+	PublicKey string `json:"public_key"`
+	Email     string `json:"email"`
 }

--- a/bridge/templates/login.html
+++ b/bridge/templates/login.html
@@ -108,6 +108,31 @@
         const authRequestID = '{{.AuthRequestID}}';
         let currentNonce = '';
 
+        // Listen for messages from the content script
+        window.addEventListener('message', (event) => {
+            if (!event.data || event.data.source !== 'cyphrmask') return;
+
+            if (event.data.type === 'EXTENSION_STATUS') {
+                const status = event.data.status;
+                if (status && status.wasmReady) {
+                    const btn = document.getElementById('sign-btn');
+                    btn.disabled = false;
+                    btn.textContent = 'Sign In with CyphrMask';
+                }
+            }
+
+            if (event.data.type === 'SIGNATURE_RESPONSE') {
+                submitCoz(event.data.coz);
+            }
+
+            if (event.data.type === 'SIGNATURE_ERROR') {
+                showStatus('Error: ' + (event.data.error || 'Unknown error'), 'error');
+                const btn = document.getElementById('sign-btn');
+                btn.disabled = false;
+                btn.textContent = 'Try Again';
+            }
+        });
+
         async function fetchChallenge() {
             try {
                 const resp = await fetch('/api/challenge');
@@ -115,51 +140,22 @@
                 const data = await resp.json();
                 currentNonce = data.nonce;
                 document.getElementById('nonce-display').textContent = data.nonce.substring(0, 32) + '...';
-                await checkExtension();
             } catch (err) {
                 showStatus('Failed to load challenge: ' + err.message, 'error');
             }
         }
 
-        async function checkExtension() {
-            try {
-                const resp = await chrome.runtime.sendMessage(
-                    { action: 'PING' }
-                ).catch(() => null);
-
-                if (resp && resp.status === 'ready') {
-                    const btn = document.getElementById('sign-btn');
-                    btn.disabled = false;
-                    btn.textContent = 'Sign In with CyphrMask';
-                } else {
-                    showStatus('Waiting for CyphrMask extension...', 'loading');
-                }
-            } catch {
-                showStatus('Waiting for CyphrMask extension...', 'loading');
-            }
-        }
-
-        document.getElementById('sign-btn').addEventListener('click', async () => {
+        document.getElementById('sign-btn').addEventListener('click', () => {
             const btn = document.getElementById('sign-btn');
             btn.disabled = true;
             btn.textContent = 'Requesting signature...';
             showStatus('Waiting for your approval in CyphrMask...', 'loading');
 
-            try {
-                const resp = await chrome.runtime.sendMessage(
-                    { action: 'REQUEST_SIGNATURE', nonce: currentNonce }
-                );
-
-                if (resp && resp.coz) {
-                    await submitCoz(resp.coz);
-                } else {
-                    throw new Error(resp?.error || 'Signature request failed');
-                }
-            } catch (err) {
-                showStatus('Error: ' + err.message, 'error');
-                btn.disabled = false;
-                btn.textContent = 'Try Again';
-            }
+            window.postMessage({
+                source: 'cyphrmask-bridge',
+                type: 'REQUEST_SIGNATURE',
+                nonce: currentNonce
+            }, '*');
         });
 
         async function submitCoz(cozString) {

--- a/cyphrmask/manifest.json
+++ b/cyphrmask/manifest.json
@@ -32,6 +32,10 @@
       "128": "assets/icon-128.png"
     }
   },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "icons": {
     "16": "assets/icon-16.png",
     "32": "assets/icon-32.png",

--- a/cyphrmask/src/background.js
+++ b/cyphrmask/src/background.js
@@ -11,7 +11,8 @@ let wasmInitError = null;
 // Initialize Wasm module on startup
 (async () => {
   try {
-    await wasmModule();
+    const wasmUrl = chrome.runtime.getURL('wasm/cyphr_crypto_bg.wasm');
+    await wasmModule(wasmUrl);
     wasmReady = true;
     console.log('[CyphrMask] Wasm crypto module initialized');
   } catch (err) {

--- a/cyphrmask/src/options/options.html
+++ b/cyphrmask/src/options/options.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CyphrMask Settings</title>
+    <link rel="stylesheet" href="../popup/popup.css">
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="./options.tsx"></script>
+</body>
+</html>

--- a/cyphrmask/src/options/options.tsx
+++ b/cyphrmask/src/options/options.tsx
@@ -1,0 +1,288 @@
+import React, { useState, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+
+interface Identity {
+    privateKey: string;
+    publicKeyX: string;
+    publicKeyY: string;
+    thumbprint: string;
+}
+
+function sendMsg(action: string, params: Record<string, unknown> = {}): Promise<any> {
+    return new Promise((resolve) => {
+        chrome.runtime.sendMessage({ action, ...params }, resolve);
+    });
+}
+
+function App() {
+    const [wasmReady, setWasmReady] = useState(false);
+    const [hasKey, setHasKey] = useState(false);
+    const [identity, setIdentity] = useState<Identity | null>(null);
+    const [importKey, setImportKey] = useState('');
+    const [importError, setImportError] = useState('');
+    const [wasmError, setWasmError] = useState<string>('');
+    const [statusMessage, setStatusMessage] = useState('');
+
+    useEffect(() => {
+        const poll = setInterval(() => {
+            sendMsg('GET_STATUS').then((response) => {
+                if (!response || response.wasmReady) {
+                    clearInterval(poll);
+                }
+                if (response) {
+                    setWasmReady(response.wasmReady);
+                    setHasKey(response.hasKey);
+                    if (response.wasmReady) {
+                        loadIdentity();
+                    } else if (response.status && response.status.startsWith('error:')) {
+                        clearInterval(poll);
+                        setWasmError(response.status.replace('error: ', ''));
+                    }
+                }
+            });
+        }, 200);
+        return () => clearInterval(poll);
+    }, []);
+
+    const loadIdentity = async () => {
+        const result = await chrome.storage.local.get(['privateKey']);
+        if (result.privateKey) {
+            const derived = await sendMsg('DERIVE_KEY', { privateKey: result.privateKey });
+            if (derived.error) {
+                console.error('[CyphrMask] Failed to derive key:', derived.error);
+                return;
+            }
+            setIdentity({
+                privateKey: result.privateKey,
+                publicKeyX: derived.public_key_x,
+                publicKeyY: derived.public_key_y,
+                thumbprint: derived.thumbprint,
+            });
+        }
+    };
+
+    const generateNewKey = async () => {
+        setImportError('');
+        const result = await sendMsg('GENERATE_KEY');
+        if (result.error) {
+            setImportError(result.error);
+            return;
+        }
+        const newIdentity: Identity = {
+            privateKey: result.privateKey,
+            publicKeyX: result.publicKeyX,
+            publicKeyY: result.publicKeyY,
+            thumbprint: result.thumbprint,
+        };
+        setIdentity(newIdentity);
+        setHasKey(true);
+        setStatusMessage('New key generated successfully.');
+    };
+
+    const importKeyHex = async () => {
+        setImportError('');
+        const hex = importKey.trim();
+        if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+            setImportError('Invalid key: must be 64 hex characters (32 bytes)');
+            return;
+        }
+        const result = await sendMsg('IMPORT_KEY', { privateKey: hex });
+        if (result.error) {
+            setImportError(result.error);
+            return;
+        }
+        const newIdentity: Identity = {
+            privateKey: result.privateKey,
+            publicKeyX: result.publicKeyX,
+            publicKeyY: result.publicKeyY,
+            thumbprint: result.thumbprint,
+        };
+        setIdentity(newIdentity);
+        setHasKey(true);
+        setImportKey('');
+        setStatusMessage('Key imported successfully.');
+    };
+
+    const importKeyFile = (file: File) => {
+        setImportError('');
+        const reader = new FileReader();
+        reader.onload = async () => {
+            try {
+                const data = JSON.parse(reader.result as string);
+                if (!data.private_key) {
+                    setImportError('Invalid backup: missing private_key');
+                    return;
+                }
+                const result = await sendMsg('IMPORT_KEY', { privateKey: data.private_key });
+                if (result.error) {
+                    setImportError(result.error);
+                    return;
+                }
+                const newIdentity: Identity = {
+                    privateKey: result.privateKey,
+                    publicKeyX: result.publicKeyX,
+                    publicKeyY: result.publicKeyY,
+                    thumbprint: result.thumbprint,
+                };
+                setIdentity(newIdentity);
+                setHasKey(true);
+                setStatusMessage('Backup imported successfully.');
+            } catch {
+                setImportError('Invalid backup file');
+            }
+        };
+        reader.readAsText(file);
+    };
+
+    const exportIdentity = () => {
+        if (!identity) return;
+        const backup = {
+            principal_root: identity.thumbprint,
+            public_key_x: identity.publicKeyX,
+            public_key_y: identity.publicKeyY,
+            private_key: identity.privateKey,
+            algorithm: 'P-256',
+            format: 'cyphr-backup-v1',
+            warning: 'Anyone with this file can impersonate you. Keep it secure.',
+        };
+        const blob = new Blob([JSON.stringify(backup, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `cyphrmask-${identity.thumbprint.substring(0, 8)}-backup.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+        setStatusMessage('Identity exported.');
+    };
+
+    const copyToClipboard = (text: string) => {
+        navigator.clipboard.writeText(text);
+    };
+
+    if (!wasmReady) {
+        if (wasmError) {
+            return (
+                <div className="container">
+                    <h2>CyphrMask Settings</h2>
+                    <p className="subtitle">Wasm Initialization Failed</p>
+                    <div className="message error">{wasmError}</div>
+                </div>
+            );
+        }
+        return (
+            <div className="container">
+                <div className="spinner" />
+                <p>Initializing crypto module...</p>
+            </div>
+        );
+    }
+
+    if (!hasKey && !identity) {
+        return (
+            <div className="container">
+                <h2>CyphrMask Settings</h2>
+                <p className="subtitle">Set up your identity</p>
+                <button className="btn-primary" onClick={generateNewKey}>
+                    Generate New Key
+                </button>
+                <div className="divider">or import</div>
+                <input
+                    type="text"
+                    className="text-input"
+                    placeholder="Paste 64-char hex private key"
+                    value={importKey}
+                    onChange={e => setImportKey(e.target.value)}
+                />
+                <button className="btn-secondary" onClick={importKeyHex}>
+                    Import Private Key
+                </button>
+                <label className="file-label">
+                    <input
+                        type="file"
+                        accept=".json"
+                        onChange={e => e.target.files?.[0] && importKeyFile(e.target.files[0])}
+                    />
+                    Import Backup File
+                </label>
+                {importError && <div className="message error">{importError}</div>}
+            </div>
+        );
+    }
+
+    return (
+        <div className="container">
+            <h2>CyphrMask Settings</h2>
+
+            {statusMessage && <div className="message success">{statusMessage}</div>}
+
+            <div className="setting-group">
+                <label>Principal Root (tmb)</label>
+                <div className="value-row">
+                    <code className="value">{identity?.thumbprint}</code>
+                    <button className="btn-icon" onClick={() => copyToClipboard(identity!.thumbprint)} title="Copy">
+                        📋
+                    </button>
+                </div>
+            </div>
+
+            <div className="setting-group">
+                <label>Public Key X</label>
+                <div className="value-row">
+                    <code className="value">{identity?.publicKeyX}</code>
+                    <button className="btn-icon" onClick={() => copyToClipboard(identity!.publicKeyX)} title="Copy">
+                        📋
+                    </button>
+                </div>
+            </div>
+
+            <div className="setting-group">
+                <label>Public Key Y</label>
+                <div className="value-row">
+                    <code className="value">{identity?.publicKeyY}</code>
+                    <button className="btn-icon" onClick={() => copyToClipboard(identity!.publicKeyY)} title="Copy">
+                        📋
+                    </button>
+                </div>
+            </div>
+
+            <div className="divider" />
+
+            <button className="btn-secondary full-width" onClick={exportIdentity}>
+                Export Identity Backup
+            </button>
+
+            <div className="divider">or import</div>
+
+            <input
+                type="text"
+                className="text-input"
+                placeholder="Paste 64-char hex private key"
+                value={importKey}
+                onChange={e => { setImportKey(e.target.value); setImportError(''); }}
+            />
+            <button className="btn-secondary full-width" onClick={importKeyHex}>
+                Import Private Key
+            </button>
+            <label className="file-label">
+                <input
+                    type="file"
+                    accept=".json"
+                    onChange={e => { e.target.files?.[0] && importKeyFile(e.target.files[0]); setImportError(''); }}
+                />
+                Import Backup File
+            </label>
+            {importError && <div className="message error">{importError}</div>}
+
+            <div className="divider" />
+
+            <button className="btn-secondary full-width" onClick={generateNewKey}>
+                Generate New Key (replaces current)
+            </button>
+        </div>
+    );
+}
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<App />);
+
+export default App;

--- a/cyphrmask/src/options/options.tsx
+++ b/cyphrmask/src/options/options.tsx
@@ -164,7 +164,7 @@ function App() {
         if (!identity) return;
         const pubKey = '04' + identity.publicKeyX + identity.publicKeyY;
         const json = `{"${identity.thumbprint}":{"public_key":"${pubKey}","email":"user@example.com"}}`;
-        navigator.clipboard.writeText(json);
+        navigator.clipboard.writeText(`BRIDGE_USERS='${json}'`);
         setStatusMessage('Bridge user JSON copied to clipboard.');
     };
 
@@ -259,11 +259,11 @@ function App() {
             <div className="setting-group">
                 <label>Bridge User JSON</label>
                 <p style={{ fontSize: '0.8rem', color: '#64748b', marginBottom: '0.5rem' }}>
-                    Paste into <code>BRIDGE_USERS</code> env var or <code>.env</code> file
+                    Click 📋 to copy — paste into <code>.env</code> at project root
                 </p>
                 <div className="value-row">
                     <code className="value" style={{ fontSize: '0.65rem', wordBreak: 'break-all' }}>
-                        {identity && `{"${identity.thumbprint}":{"public_key":"04${identity.publicKeyX}${identity.publicKeyY}","email":"user@example.com"}}`}
+                        {identity && `BRIDGE_USERS='{"${identity.thumbprint}":{"public_key":"04${identity.publicKeyX}${identity.publicKeyY}","email":"user@example.com"}}'`}
                     </code>
                     <button className="btn-icon" onClick={copyBridgeUserJSON} title="Copy">
                         📋

--- a/cyphrmask/src/options/options.tsx
+++ b/cyphrmask/src/options/options.tsx
@@ -127,7 +127,8 @@ function App() {
                 setIdentity(newIdentity);
                 setHasKey(true);
                 setStatusMessage('Backup imported successfully.');
-            } catch {
+            } catch (err) {
+                console.error('[CyphrMask] Failed to import backup:', err);
                 setImportError('Invalid backup file');
             }
         };

--- a/cyphrmask/src/options/options.tsx
+++ b/cyphrmask/src/options/options.tsx
@@ -160,6 +160,14 @@ function App() {
         navigator.clipboard.writeText(text);
     };
 
+    const copyBridgeUserJSON = () => {
+        if (!identity) return;
+        const pubKey = '04' + identity.publicKeyX + identity.publicKeyY;
+        const json = `{"${identity.thumbprint}":{"public_key":"${pubKey}","email":"user@example.com"}}`;
+        navigator.clipboard.writeText(json);
+        setStatusMessage('Bridge user JSON copied to clipboard.');
+    };
+
     if (!wasmReady) {
         if (wasmError) {
             return (
@@ -241,6 +249,23 @@ function App() {
                 <div className="value-row">
                     <code className="value">{identity?.publicKeyY}</code>
                     <button className="btn-icon" onClick={() => copyToClipboard(identity!.publicKeyY)} title="Copy">
+                        📋
+                    </button>
+                </div>
+            </div>
+
+            <div className="divider" />
+
+            <div className="setting-group">
+                <label>Bridge User JSON</label>
+                <p style={{ fontSize: '0.8rem', color: '#64748b', marginBottom: '0.5rem' }}>
+                    Paste into <code>BRIDGE_USERS</code> env var or <code>.env</code> file
+                </p>
+                <div className="value-row">
+                    <code className="value" style={{ fontSize: '0.65rem', wordBreak: 'break-all' }}>
+                        {identity && `{"${identity.thumbprint}":{"public_key":"04${identity.publicKeyX}${identity.publicKeyY}","email":"user@example.com"}}`}
+                    </code>
+                    <button className="btn-icon" onClick={copyBridgeUserJSON} title="Copy">
                         📋
                     </button>
                 </div>

--- a/cyphrmask/src/popup/popup.tsx
+++ b/cyphrmask/src/popup/popup.tsx
@@ -148,6 +148,15 @@ function App() {
         chrome.runtime.openOptionsPage();
     };
 
+    const copyBridgeUserJSON = () => {
+        if (!identity) return;
+        const pubKey = '04' + identity.publicKeyX + identity.publicKeyY;
+        const json = `{"${identity.thumbprint}":{"public_key":"${pubKey}","email":"user@example.com"}}`;
+        navigator.clipboard.writeText(json);
+        setMessage('Bridge user JSON copied!');
+        setMessageType('success');
+    };
+
     const exportIdentity = () => {
         if (!identity) return;
         const backup = {
@@ -331,6 +340,10 @@ function App() {
                     </div>
 
                     <div className="divider" />
+
+                    <button className="btn-secondary full-width" onClick={copyBridgeUserJSON} title="Copy BRIDGE_USERS JSON">
+                        Copy Bridge User JSON
+                    </button>
 
                     <button className="btn-secondary full-width" onClick={exportIdentity}>
                         Export Identity Backup

--- a/cyphrmask/src/popup/popup.tsx
+++ b/cyphrmask/src/popup/popup.tsx
@@ -365,6 +365,11 @@ function App() {
                         Import Backup File (opens settings)
                     </button>
                     {importError && <div className="message error">{importError}</div>}
+                    {message && (
+                        <div className={`message ${messageType}`}>
+                            {message}
+                        </div>
+                    )}
                 </div>
             )}
         </div>

--- a/cyphrmask/src/popup/popup.tsx
+++ b/cyphrmask/src/popup/popup.tsx
@@ -152,7 +152,7 @@ function App() {
         if (!identity) return;
         const pubKey = '04' + identity.publicKeyX + identity.publicKeyY;
         const json = `{"${identity.thumbprint}":{"public_key":"${pubKey}","email":"user@example.com"}}`;
-        navigator.clipboard.writeText(json);
+        navigator.clipboard.writeText(`BRIDGE_USERS='${json}'`);
         setMessage('Bridge user JSON copied!');
         setMessageType('success');
     };

--- a/cyphrmask/src/popup/popup.tsx
+++ b/cyphrmask/src/popup/popup.tsx
@@ -144,34 +144,8 @@ function App() {
         setImportKey('');
     };
 
-    const importKeyFile = (file: File) => {
-        setImportError('');
-        const reader = new FileReader();
-        reader.onload = async () => {
-            try {
-                const data = JSON.parse(reader.result as string);
-                if (!data.private_key) {
-                    setImportError('Invalid backup: missing private_key');
-                    return;
-                }
-                const result = await sendMsg('IMPORT_KEY', { privateKey: data.private_key });
-                if (result.error) {
-                    setImportError(result.error);
-                    return;
-                }
-                const newIdentity: Identity = {
-                    privateKey: result.privateKey,
-                    publicKeyX: result.publicKeyX,
-                    publicKeyY: result.publicKeyY,
-                    thumbprint: result.thumbprint,
-                };
-                setIdentity(newIdentity);
-                setStatus(prev => ({ ...prev, hasKey: true }));
-            } catch {
-                setImportError('Invalid backup file');
-            }
-        };
-        reader.readAsText(file);
+    const openSettings = () => {
+        chrome.runtime.openOptionsPage();
     };
 
     const exportIdentity = () => {
@@ -275,14 +249,9 @@ function App() {
                 <button className="btn-secondary" onClick={importKeyHex}>
                     Import Private Key
                 </button>
-                <label className="file-label">
-                    <input
-                        type="file"
-                        accept=".json"
-                        onChange={e => e.target.files?.[0] && importKeyFile(e.target.files[0])}
-                    />
-                    Import Backup File
-                </label>
+                <button className="btn-secondary full-width" onClick={openSettings}>
+                    Import Backup File (opens settings)
+                </button>
                 {importError && <div className="message error">{importError}</div>}
             </div>
         );
@@ -379,14 +348,9 @@ function App() {
                     <button className="btn-secondary full-width" onClick={importKeyHex}>
                         Import Private Key
                     </button>
-                    <label className="file-label">
-                        <input
-                            type="file"
-                            accept=".json"
-                            onChange={e => { e.target.files?.[0] && importKeyFile(e.target.files[0]); setImportError(''); }}
-                        />
-                        Import Backup File
-                    </label>
+                    <button className="btn-secondary full-width" onClick={openSettings}>
+                        Import Backup File (opens settings)
+                    </button>
                     {importError && <div className="message error">{importError}</div>}
                 </div>
             )}

--- a/cyphrmask/vite.config.js
+++ b/cyphrmask/vite.config.js
@@ -50,11 +50,19 @@ export default defineConfig({
           .replace('href="../../assets/', 'href="./assets/');
         writeFileSync(resolve(dist, 'popup.html'), fixedHtml);
 
+        // Flatten options.html with corrected paths
+        const optHtml = readFileSync(resolve(dist, 'src/options/options.html'), 'utf-8');
+        const fixedOptHtml = optHtml
+          .replace('src="./options.tsx"', 'src="./options.js"')
+          .replace('href="../../assets/', 'href="./assets/');
+        writeFileSync(resolve(dist, 'options.html'), fixedOptHtml);
+
         // Update manifest paths for dist layout
         const manifest = JSON.parse(readFileSync(resolve(root, 'manifest.json'), 'utf-8'));
         manifest.content_scripts[0].js = ['content.js'];
         manifest.background.service_worker = 'background.js';
         manifest.action.default_popup = 'popup.html';
+        manifest.options_ui.page = 'options.html';
         writeFileSync(resolve(dist, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
       },
     },
@@ -65,6 +73,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         popup: 'src/popup/popup.html',
+        options: 'src/options/options.html',
       },
       output: {
         entryFileNames: '[name].js',

--- a/cyphrmask/wasm-crypto/src/lib.rs
+++ b/cyphrmask/wasm-crypto/src/lib.rs
@@ -55,10 +55,9 @@ fn sign_bytes(data: &[u8], private_key_hex: &str) -> String {
 
     let signing_key = SigningKey::from(secret_key);
 
-    // Hash the data first (ES256 = ECDSA + SHA-256)
-    let hash = Sha256::digest(data);
-
-    let signature: Signature = signing_key.sign(&hash);
+    // ecdsa::SigningKey::sign already hashes with SHA-256 internally.
+    // Do NOT pre-hash — signing a pre-hashed value would double-hash.
+    let signature: Signature = signing_key.sign(data);
 
     // Encode as base64url (r || s concatenation)
     let sig_bytes = signature.to_bytes();

--- a/justfile
+++ b/justfile
@@ -36,7 +36,7 @@ lint:
 
 # Run bridge locally for dev testing
 run:
-    mkdir -p .keys
+    mkdir -p bridge/.keys
     cd bridge && go run ./...
 
 # Start local dev stack

--- a/justfile
+++ b/justfile
@@ -2,6 +2,7 @@
 # Install: https://github.com/casey/just
 
 set shell := ["bash", "-c"]
+set dotenv-load
 
 # Compile Go binary
 build-bridge:

--- a/justfile
+++ b/justfile
@@ -33,6 +33,10 @@ fmt:
 lint:
     cd bridge && go vet ./...
 
+# Run bridge locally for dev testing
+run:
+    cd bridge && go run ./...
+
 # Start local dev stack
 up:
     docker compose up -d

--- a/justfile
+++ b/justfile
@@ -36,6 +36,7 @@ lint:
 
 # Run bridge locally for dev testing
 run:
+    mkdir -p .keys
     cd bridge && go run ./...
 
 # Start local dev stack


### PR DESCRIPTION
**Cyphr-OIDC authentication now works end-to-end** — from the OIDC
`/authorize` redirect through the login page, extension signature
approval, Coz verification, and final redirect to the client's
callback URL.

The options page solves the Linux Chromium popup crash (issues
[40276394](https://issues.chromium.org/issues/40276394),
[40638231](https://issues.chromium.org/issues/40638231)) where the
native file picker kills the extension popup process. File import/export
and full key management now live in a dedicated options tab that opens
as a full browser tab. The popup's "Import Backup File" button routes
there instead.

The login page (`login.html`) was rewritten to use `window.postMessage`
through the content script bridge instead of calling `chrome.runtime.sendMessage`
directly — which fails in web page contexts where that API is undefined.

Several bugs surfaced during testing and were fixed in the same branch:
wasm module initialization in the service worker, JSON unquoting for
signature extraction, empty public key loading from `.env` (missing
struct tags), a double-hash in the Rust signing path, and a 404 on the
final OIDC callback redirect.

> **Setup:** Copy your `BRIDGE_USERS` JSON from the extension's Settings
> tab and paste it into `.env` at the project root. Run `just run` to
> start the bridge with your user registered.

### Try it locally

```sh
git clone https://github.com/ic4y/cyphr-OIDC.git
cd cyphr-OIDC
# Load your extension's BRIDGE_USERS into .env
cp .env.example .env
just run
# Visit http://localhost:8080/authorize?client_id=cyphrmask-poc&redirect_uri=http://localhost:8080/callback&response_type=code&scope=openid%20profile&state=random123
```