### PR TITLE
Integrate Forgejo into docker-compose with auto-configured OIDC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ bridge/.keys/
 .DS_Store
 Thumbs.db
 docs/
+forgejo/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ No fork, no patch, no protocol changes to downstream apps. They just see a stand
 ### From Scratch (5 minutes)
 
 ```bash
+# 0. Add bridge hostname to /etc/hosts (required for browser access)
+echo "127.0.0.1 cyphr-bridge" | sudo tee -a /etc/hosts
+
 # 1. Enter the dev shell (NixOS)
 nix develop
 
@@ -23,12 +26,12 @@ just build
 just up
 
 # 4. Verify it's running
-curl http://localhost:8080/.well-known/openid-configuration
-curl http://localhost:8080/health
+curl http://cyphr-bridge:8080/.well-known/openid-configuration
+curl http://cyphr-bridge:8080/health
 curl http://localhost:3000
 ```
 
-The bridge is now serving as an OIDC provider on `http://localhost:8080`. Forgejo is available at `http://localhost:3000` with an admin user (`forgejo-admin`/`admin123`) and the CyphrMask OIDC auth source pre-registered. Open `http://localhost:3000/user/login` and click **Sign in with CyphrMask** to test.
+The bridge is now serving as an OIDC provider on `http://cyphr-bridge:8080`. Forgejo is available at `http://localhost:3000` with an admin user (`forgejo-admin`/`admin123`) and the CyphrMask OIDC auth source pre-registered. Open `http://localhost:3000/user/login` and click **Sign in with CyphrMask** to test.
 
 ### Deploying a Docker Image
 
@@ -142,7 +145,7 @@ In `bridge/main.go`, add Forgejo as an OIDC client:
 oidcStore.RegisterClient(storage.NewClient(
     "forgejo",                         // client_id
     "forgejo-secret",                  // client_secret (save this!)
-    []string{"https://forgejo.example.com/user/oauth2/Cyphr/callback"},
+    []string{"https://forgejo.example.com/user/oauth2/CyphrMask/callback"},
     func(id string) string {
         return "/login?authRequestID=" + id
     },
@@ -198,21 +201,21 @@ This is [an open issue](https://codeberg.org/forgejo/forgejo/issues/732) in Forg
 Any OIDC-capable application can use the Bridge. Register clients via the `BRIDGE_CLIENTS` environment variable:
 
 ```bash
-BRIDGE_CLIENTS='[{"id":"forgejo","secret":"forgejo-secret","redirect_uris":["https://forgejo.example/user/oauth2/Cyphr/callback"]}]'
+BRIDGE_CLIENTS='[{"id":"forgejo","secret":"forgejo-secret","redirect_uris":["https://forgejo.example/user/oauth2/CyphrMask/callback"]}]'
 ```
 
 Or in `docker-compose.yml`:
 
 ```yaml
 environment:
-  - BRIDGE_CLIENTS=[{"id":"forgejo","secret":"forgejo-secret","redirect_uris":["https://forgejo.example/user/oauth2/Cyphr/callback"]}]
+  - BRIDGE_CLIENTS=[{"id":"forgejo","secret":"forgejo-secret","redirect_uris":["https://forgejo.example/user/oauth2/CyphrMask/callback"]}]
 ```
 
 To register multiple clients:
 
 ```json
 [
-  {"id":"forgejo","secret":"forgejo-secret","redirect_uris":["https://forgejo.example/user/oauth2/Cyphr/callback"]},
+  {"id":"forgejo","secret":"forgejo-secret","redirect_uris":["https://forgejo.example/user/oauth2/CyphrMask/callback"]},
   {"id":"grafana","secret":"grafana-secret","redirect_uris":["https://grafana.example/login/generic_oauth"]}
 ]
 ```
@@ -362,7 +365,7 @@ All configuration is via environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `BRIDGE_PORT` | `8080` | HTTP listen port |
-| `BRIDGE_ISSUER_URL` | `http://localhost:8080` | OIDC issuer URL (must match the public URL) |
+| `BRIDGE_ISSUER_URL` | `http://cyphr-bridge:8080` | OIDC issuer URL (must match the public URL; use `localhost` only if Forgejo runs on the same host) |
 | `BRIDGE_CLIENT_ID` | `cyphrmask-poc` | Default client ID |
 | `BRIDGE_CLIENT_SECRET` | `dev-secret-change-me` | Default client secret |
 | `BRIDGE_CALLBACK_URL` | `http://localhost:8080/callback` | OAuth2 callback URI |

--- a/README.md
+++ b/README.md
@@ -19,15 +19,16 @@ nix develop
 # 2. Build everything
 just build
 
-# 3. Start the bridge
+# 3. Start the full stack (bridge + redis + forgejo)
 just up
 
 # 4. Verify it's running
 curl http://localhost:8080/.well-known/openid-configuration
 curl http://localhost:8080/health
+curl http://localhost:3000
 ```
 
-The bridge is now serving as an OIDC provider on `http://localhost:8080`. See [Registering a Client Application](#registering-a-client-application) below for connecting Forgejo or any other OIDC-capable app.
+The bridge is now serving as an OIDC provider on `http://localhost:8080`. Forgejo is available at `http://localhost:3000` with an admin user (`admin`/`admin123`) and the CyphrMask OIDC auth source pre-registered. Open `http://localhost:3000/user/login` and click **Sign in with CyphrMask** to test.
 
 ### Deploying a Docker Image
 
@@ -120,9 +121,20 @@ For production deployments, remove `http://localhost:8080/*` from `host_permissi
 
 ## Forgejo Integration
 
-Forgejo supports OpenID Connect authentication natively. Here's how to register the Bridge as an OIDC login source.
+Forgejo supports OpenID Connect authentication natively. The `docker-compose.yml` includes a pre-configured Forgejo instance with SQLite — no external database required.
 
-### Step 1: Register the Bridge as a Client
+### Automated Setup (PoC)
+
+`just up` starts Forgejo with:
+- SQLite database (no Postgres/MySQL)
+- Admin user: `admin` / `admin123`
+- CyphrMask OIDC auth source pre-registered via `forgejo admin auth add-oauth`
+
+Just open `http://localhost:3000/user/login` and click **Sign in with CyphrMask**.
+
+### Manual Setup (Production)
+
+For production deployments, register the Bridge as an OIDC client:
 
 In `bridge/main.go`, add Forgejo as an OIDC client:
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ No fork, no patch, no protocol changes to downstream apps. They just see a stand
 ### From Scratch (5 minutes)
 
 ```bash
-# 0. Add bridge hostname to /etc/hosts (required for browser access)
-echo "127.0.0.1 cyphr-bridge" | sudo tee -a /etc/hosts
-
 # 1. Enter the dev shell (NixOS)
 nix develop
 
@@ -26,12 +23,12 @@ just build
 just up
 
 # 4. Verify it's running
-curl http://cyphr-bridge:8080/.well-known/openid-configuration
-curl http://cyphr-bridge:8080/health
+curl http://localhost:8080/.well-known/openid-configuration
+curl http://localhost:8080/health
 curl http://localhost:3000
 ```
 
-The bridge is now serving as an OIDC provider on `http://cyphr-bridge:8080`. Forgejo is available at `http://localhost:3000` with an admin user (`forgejo-admin`/`admin123`) and the CyphrMask OIDC auth source pre-registered. Open `http://localhost:3000/user/login` and click **Sign in with CyphrMask** to test.
+The bridge is now serving as an OIDC provider on `http://localhost:8080`. Forgejo is available at `http://localhost:3000` with an admin user (`forgejo-admin`/`admin123`) and the CyphrMask OIDC auth source pre-registered. Open `http://localhost:3000/user/login` and click **Sign in with CyphrMask** to test.
 
 ### Deploying a Docker Image
 
@@ -365,7 +362,7 @@ All configuration is via environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `BRIDGE_PORT` | `8080` | HTTP listen port |
-| `BRIDGE_ISSUER_URL` | `http://cyphr-bridge:8080` | OIDC issuer URL (must match the public URL; use `localhost` only if Forgejo runs on the same host) |
+| `BRIDGE_ISSUER_URL` | `http://localhost:8080` | OIDC issuer URL (must match the public URL) |
 | `BRIDGE_CLIENT_ID` | `cyphrmask-poc` | Default client ID |
 | `BRIDGE_CLIENT_SECRET` | `dev-secret-change-me` | Default client secret |
 | `BRIDGE_CALLBACK_URL` | `http://localhost:8080/callback` | OAuth2 callback URI |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ curl http://localhost:8080/health
 curl http://localhost:3000
 ```
 
-The bridge is now serving as an OIDC provider on `http://localhost:8080`. Forgejo is available at `http://localhost:3000` with an admin user (`admin`/`admin123`) and the CyphrMask OIDC auth source pre-registered. Open `http://localhost:3000/user/login` and click **Sign in with CyphrMask** to test.
+The bridge is now serving as an OIDC provider on `http://localhost:8080`. Forgejo is available at `http://localhost:3000` with an admin user (`forgejo-admin`/`admin123`) and the CyphrMask OIDC auth source pre-registered. Open `http://localhost:3000/user/login` and click **Sign in with CyphrMask** to test.
 
 ### Deploying a Docker Image
 
@@ -127,7 +127,7 @@ Forgejo supports OpenID Connect authentication natively. The `docker-compose.yml
 
 `just up` starts Forgejo with:
 - SQLite database (no Postgres/MySQL)
-- Admin user: `admin` / `admin123`
+- Admin user: `forgejo-admin` / `admin123`
 - CyphrMask OIDC auth source pre-registered via `forgejo admin auth add-oauth`
 
 Just open `http://localhost:3000/user/login` and click **Sign in with CyphrMask**.

--- a/README.md
+++ b/README.md
@@ -13,20 +13,30 @@ No fork, no patch, no protocol changes to downstream apps. They just see a stand
 ### From Scratch (5 minutes)
 
 ```bash
-# 0. Allow container-to-host traffic on port 8080
+# 0. Copy environment defaults
+cp .env.example .env
+
+# 1. Allow container-to-host traffic on port 8080
 sudo iptables -I INPUT -p tcp --dport 8080 -j ACCEPT
 # To remove later: sudo iptables -D INPUT -p tcp --dport 8080 -j ACCEPT
 
-# 1. Enter the dev shell (NixOS)
+# 2. Enter the dev shell (NixOS)
 nix develop
 
-# 2. Build everything
+# 3. Build everything
 just build
 
-# 3. Start the full stack (bridge + redis + forgejo)
+# 4. Start the full stack (bridge + redis + forgejo)
 just up
 
-# 4. Verify it's running
+# 5. Generate your key and register your identity
+#    5a. Load the CyphrMask extension (see "Installing the CyphrMask Extension" below)
+#    5b. Click the extension icon → Generate New Key
+#    5c. Switch to Settings tab → click "Copy Bridge User JSON"
+#    5d. Paste into .env: BRIDGE_USERS='<paste here>'
+#    5e. Restart the bridge: just down && just up
+
+# 6. Verify it's running
 curl http://localhost:8080/.well-known/openid-configuration
 curl http://localhost:8080/health
 curl http://localhost:3000
@@ -277,10 +287,12 @@ The Bridge needs to map your Principal Root (`tmb`) to an identity (email + publ
 
 ### Option 1: Environment Variable (recommended for testing)
 
-Copy your `tmb` and public key from the extension's Settings tab, then set:
+In the extension's **Settings** tab, click **Copy Bridge User JSON**. This copies a ready-to-paste `BRIDGE_USERS='...'` line to your clipboard. Paste it into your `.env` file and restart the bridge.
+
+Or construct it manually from your `tmb` and public key:
 
 ```bash
-BRIDGE_USERS='{"cLj8vsYt...":{"email":"you@example.com","public_key":"-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"}}'
+BRIDGE_USERS='{"cLj8vsYt...":{"email":"you@example.com","public_key":"04..."}}'
 ```
 
 Or add to `docker-compose.yml`:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ No fork, no patch, no protocol changes to downstream apps. They just see a stand
 ### From Scratch (5 minutes)
 
 ```bash
+# 0. Allow container-to-host traffic on port 8080
+sudo iptables -I INPUT -p tcp --dport 8080 -j ACCEPT
+# To remove later: sudo iptables -D INPUT -p tcp --dport 8080 -j ACCEPT
+
 # 1. Enter the dev shell (NixOS)
 nix develop
 
@@ -28,7 +32,7 @@ curl http://localhost:8080/health
 curl http://localhost:3000
 ```
 
-The bridge is now serving as an OIDC provider on `http://localhost:8080`. Forgejo is available at `http://localhost:3000` with an admin user (`forgejo-admin`/`admin123`) and the CyphrMask OIDC auth source pre-registered. Open `http://localhost:3000/user/login` and click **Sign in with CyphrMask** to test.
+The bridge runs directly on the host network (`:8080`). Forgejo uses `extra_hosts` to resolve `localhost` to the Docker host gateway, so the OIDC token exchange works from inside the container. Forgejo is available at `http://localhost:3000` with an admin user (`forgejo-admin`/`admin123`) and the CyphrMask OIDC auth source pre-registered. Open `http://localhost:3000/user/login` and click **Sign in with CyphrMask** to test.
 
 ### Deploying a Docker Image
 

--- a/bridge/handlers/verify.go
+++ b/bridge/handlers/verify.go
@@ -104,10 +104,10 @@ func HandleVerify(store *ChallengeStore, oidcStore *storage.Storage, usersJSON s
 			return
 		}
 
-		// Complete the OIDC auth request with the user's email as subject
+		// Complete the OIDC auth request with thumbprint as subject and email in claims
 		authReqID := r.URL.Query().Get("authRequestID")
 		if authReqID != "" {
-			oidcStore.CompleteAuthRequest(authReqID, user.Email)
+			oidcStore.CompleteAuthRequest(authReqID, pay.Tmb, user.Email)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/bridge/storage/storage.go
+++ b/bridge/storage/storage.go
@@ -58,6 +58,7 @@ type AuthRequest struct {
 	State         string
 	Nonce         string
 	UserID        string
+	Email         string
 	completed     bool
 	AuthTime      time.Time
 	ResponseType  oidc.ResponseType
@@ -77,6 +78,7 @@ func (a *AuthRequest) GetResponseMode() oidc.ResponseMode    { return "" }
 func (a *AuthRequest) GetScopes() []string                   { return a.Scopes }
 func (a *AuthRequest) GetState() string                      { return a.State }
 func (a *AuthRequest) GetSubject() string                    { return a.UserID }
+func (a *AuthRequest) GetEmail() string                      { return a.Email }
 func (a *AuthRequest) Done() bool                            { return a.completed }
 
 type Client struct {
@@ -134,6 +136,7 @@ type Token struct {
 	ApplicationID  string
 	RefreshTokenID string
 	Subject        string
+	Email          string
 	Audience       []string
 	Expiration     time.Time
 	Scopes         []string
@@ -146,6 +149,7 @@ type RefreshToken struct {
 	AMR           []string
 	ApplicationID string
 	UserID        string
+	Email         string
 	Audience      []string
 	Expiration    time.Time
 	Scopes        []string
@@ -207,11 +211,12 @@ func (s *Storage) RegisterClient(c *Client) {
 	s.clients[c.id] = c
 }
 
-func (s *Storage) CompleteAuthRequest(id, userID string) {
+func (s *Storage) CompleteAuthRequest(id, subject, email string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if req, ok := s.authRequests[id]; ok {
-		req.UserID = userID
+		req.UserID = subject
+		req.Email = email
 		req.ApplicationID = req.ClientID
 		req.completed = true
 		req.AuthTime = time.Now()
@@ -294,13 +299,14 @@ func (s *Storage) DeleteAuthRequest(ctx context.Context, id string) error {
 }
 
 func (s *Storage) CreateAccessToken(ctx context.Context, request op.TokenRequest) (string, time.Time, error) {
-	var applicationID string
+	var applicationID, email string
 	switch req := request.(type) {
 	case *AuthRequest:
 		applicationID = req.ApplicationID
+		email = req.Email
 	}
 
-	token, err := s.createAccessToken(applicationID, "", request.GetSubject(), request.GetAudience(), request.GetScopes())
+	token, err := s.createAccessToken(applicationID, "", request.GetSubject(), email, request.GetAudience(), request.GetScopes())
 	if err != nil {
 		return "", time.Time{}, err
 	}
@@ -310,9 +316,17 @@ func (s *Storage) CreateAccessToken(ctx context.Context, request op.TokenRequest
 func (s *Storage) CreateAccessAndRefreshTokens(ctx context.Context, request op.TokenRequest, currentRefreshToken string) (accessTokenID, newRefreshTokenID string, expiration time.Time, err error) {
 	applicationID, authTime, amr := getInfoFromRequest(request)
 
+	var email string
+	switch req := request.(type) {
+	case *AuthRequest:
+		email = req.Email
+	case *RefreshTokenRequest:
+		email = req.Email
+	}
+
 	if currentRefreshToken == "" {
 		refreshTokenID := uuid.NewString()
-		accessToken, err := s.createAccessToken(applicationID, refreshTokenID, request.GetSubject(), request.GetAudience(), request.GetScopes())
+		accessToken, err := s.createAccessToken(applicationID, refreshTokenID, request.GetSubject(), email, request.GetAudience(), request.GetScopes())
 		if err != nil {
 			return "", "", time.Time{}, err
 		}
@@ -321,7 +335,7 @@ func (s *Storage) CreateAccessAndRefreshTokens(ctx context.Context, request op.T
 	}
 
 	newRefreshTokenID = uuid.NewString()
-	accessToken, err := s.createAccessToken(applicationID, newRefreshTokenID, request.GetSubject(), request.GetAudience(), request.GetScopes())
+	accessToken, err := s.createAccessToken(applicationID, newRefreshTokenID, request.GetSubject(), email, request.GetAudience(), request.GetScopes())
 	if err != nil {
 		return "", "", time.Time{}, err
 	}
@@ -341,6 +355,7 @@ func (s *Storage) TokenRequestByRefreshToken(ctx context.Context, refreshToken s
 	return &RefreshTokenRequest{
 		ApplicationID: token.ApplicationID,
 		Subject:       token.UserID,
+		Email:         token.Email,
 		AuthTime:      token.AuthTime,
 		AMR:           token.AMR,
 		Audience:      token.Audience,
@@ -425,6 +440,26 @@ func (s *Storage) AuthorizeClientIDSecret(ctx context.Context, clientID, clientS
 }
 
 func (s *Storage) SetUserinfoFromScopes(ctx context.Context, userinfo *oidc.UserInfo, userID, clientID string, scopes []string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	userinfo.Subject = userID
+	var email string
+	for _, req := range s.authRequests {
+		if req.UserID == userID && req.Email != "" {
+			email = req.Email
+			break
+		}
+	}
+	for _, scope := range scopes {
+		switch scope {
+		case oidc.ScopeEmail:
+			userinfo.Email = email
+			userinfo.EmailVerified = email != ""
+		case oidc.ScopeProfile:
+			userinfo.PreferredUsername = userID
+			userinfo.Name = userID
+		}
+	}
 	return nil
 }
 
@@ -434,10 +469,12 @@ func (s *Storage) SetUserinfoFromRequest(ctx context.Context, userinfo *oidc.Use
 	userinfo.Subject = token.GetSubject()
 	for _, scope := range scopes {
 		switch scope {
-		case oidc.ScopeOpenID:
-			userinfo.Subject = token.GetSubject()
 		case oidc.ScopeEmail:
-			userinfo.Email = token.GetSubject()
+			if ar, ok := token.(*AuthRequest); ok {
+				userinfo.Email = ar.Email
+			} else {
+				userinfo.Email = token.GetSubject()
+			}
 			userinfo.EmailVerified = true
 		case oidc.ScopeProfile:
 			userinfo.PreferredUsername = token.GetSubject()
@@ -460,9 +497,8 @@ func (s *Storage) SetUserinfoFromToken(ctx context.Context, userinfo *oidc.UserI
 	userinfo.Subject = token.Subject
 	for _, scope := range token.Scopes {
 		switch scope {
-		case oidc.ScopeOpenID:
 		case oidc.ScopeEmail:
-			userinfo.Email = token.Subject
+			userinfo.Email = token.Email
 			userinfo.EmailVerified = true
 		case oidc.ScopeProfile:
 			userinfo.PreferredUsername = token.Subject
@@ -491,7 +527,27 @@ func (s *Storage) SetIntrospectionFromToken(ctx context.Context, introspection *
 }
 
 func (s *Storage) GetPrivateClaimsFromScopes(ctx context.Context, userID, clientID string, scopes []string) (map[string]any, error) {
-	return nil, nil
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	claims := make(map[string]any)
+	var email string
+	for _, req := range s.authRequests {
+		if req.UserID == userID && req.Email != "" {
+			email = req.Email
+			break
+		}
+	}
+	for _, scope := range scopes {
+		switch scope {
+		case oidc.ScopeEmail:
+			claims["email"] = email
+			claims["email_verified"] = email != ""
+		case oidc.ScopeProfile:
+			claims["preferred_username"] = email
+			claims["name"] = email
+		}
+	}
+	return claims, nil
 }
 
 func (s *Storage) GetKeyByIDAndClientID(ctx context.Context, keyID, clientID string) (*jose.JSONWebKey, error) {
@@ -523,7 +579,7 @@ func (s *Storage) ClientCredentialsTokenRequest(ctx context.Context, clientID st
 	return nil, fmt.Errorf("client_credentials grant not supported")
 }
 
-func (s *Storage) createAccessToken(applicationID, refreshTokenID, subject string, audience, scopes []string) (*Token, error) {
+func (s *Storage) createAccessToken(applicationID, refreshTokenID, subject, email string, audience, scopes []string) (*Token, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	token := &Token{
@@ -531,6 +587,7 @@ func (s *Storage) createAccessToken(applicationID, refreshTokenID, subject strin
 		ApplicationID:  applicationID,
 		RefreshTokenID: refreshTokenID,
 		Subject:        subject,
+		Email:          email,
 		Audience:       audience,
 		Expiration:     time.Now().Add(5 * time.Minute),
 		Scopes:         scopes,
@@ -549,6 +606,7 @@ func (s *Storage) createRefreshToken(accessToken *Token, amr []string, authTime 
 		AMR:           amr,
 		ApplicationID: accessToken.ApplicationID,
 		UserID:        accessToken.Subject,
+		Email:         accessToken.Email,
 		Audience:      accessToken.Audience,
 		Expiration:    time.Now().Add(5 * time.Hour),
 		Scopes:        accessToken.Scopes,
@@ -593,6 +651,7 @@ func getInfoFromRequest(req op.TokenRequest) (clientID string, authTime time.Tim
 type RefreshTokenRequest struct {
 	ApplicationID string
 	Subject       string
+	Email         string
 	AuthTime      time.Time
 	AMR           []string
 	Audience      []string

--- a/bridge/storage/storage.go
+++ b/bridge/storage/storage.go
@@ -517,6 +517,10 @@ func (s *Storage) SetIntrospectionFromToken(ctx context.Context, introspection *
 	return fmt.Errorf("token not valid for this client")
 }
 
+// findEmailBySubject looks up the email for a given subject (thumbprint or user ID)
+// by scanning in-memory auth requests. The auth request is deleted by zitadel only
+// after both the access token and ID token are created (op/token.go:50), so this
+// lookup succeeds during the token creation flow.
 func (s *Storage) findEmailBySubject(userID string) string {
 	for _, req := range s.authRequests {
 		if req.UserID == userID && req.Email != "" {

--- a/bridge/storage/storage.go
+++ b/bridge/storage/storage.go
@@ -78,7 +78,6 @@ func (a *AuthRequest) GetResponseMode() oidc.ResponseMode    { return "" }
 func (a *AuthRequest) GetScopes() []string                   { return a.Scopes }
 func (a *AuthRequest) GetState() string                      { return a.State }
 func (a *AuthRequest) GetSubject() string                    { return a.UserID }
-func (a *AuthRequest) GetEmail() string                      { return a.Email }
 func (a *AuthRequest) Done() bool                            { return a.completed }
 
 type Client struct {
@@ -443,13 +442,7 @@ func (s *Storage) SetUserinfoFromScopes(ctx context.Context, userinfo *oidc.User
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	userinfo.Subject = userID
-	var email string
-	for _, req := range s.authRequests {
-		if req.UserID == userID && req.Email != "" {
-			email = req.Email
-			break
-		}
-	}
+	email := s.findEmailBySubject(userID)
 	for _, scope := range scopes {
 		switch scope {
 		case oidc.ScopeEmail:
@@ -472,10 +465,8 @@ func (s *Storage) SetUserinfoFromRequest(ctx context.Context, userinfo *oidc.Use
 		case oidc.ScopeEmail:
 			if ar, ok := token.(*AuthRequest); ok {
 				userinfo.Email = ar.Email
-			} else {
-				userinfo.Email = token.GetSubject()
 			}
-			userinfo.EmailVerified = true
+			userinfo.EmailVerified = userinfo.Email != ""
 		case oidc.ScopeProfile:
 			userinfo.PreferredUsername = token.GetSubject()
 			userinfo.Name = token.GetSubject()
@@ -526,17 +517,20 @@ func (s *Storage) SetIntrospectionFromToken(ctx context.Context, introspection *
 	return fmt.Errorf("token not valid for this client")
 }
 
+func (s *Storage) findEmailBySubject(userID string) string {
+	for _, req := range s.authRequests {
+		if req.UserID == userID && req.Email != "" {
+			return req.Email
+		}
+	}
+	return ""
+}
+
 func (s *Storage) GetPrivateClaimsFromScopes(ctx context.Context, userID, clientID string, scopes []string) (map[string]any, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	claims := make(map[string]any)
-	var email string
-	for _, req := range s.authRequests {
-		if req.UserID == userID && req.Email != "" {
-			email = req.Email
-			break
-		}
-	}
+	email := s.findEmailBySubject(userID)
 	for _, scope := range scopes {
 		switch scope {
 		case oidc.ScopeEmail:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
   forgejo-init:
     image: codeberg.org/forgejo/forgejo:14
     container_name: forgejo-init
+    user: "1000:1000"
     depends_on:
       forgejo:
         condition: service_healthy
@@ -64,7 +65,7 @@ services:
       - |
         echo "Creating admin user..."
         forgejo admin user create \
-          --username admin \
+          --username forgejo-admin \
           --password admin123 \
           --email admin@localhost \
           --admin \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: cyphr-bridge
     environment:
       - BRIDGE_PORT=8080
-      - BRIDGE_ISSUER_URL=http://cyphr-bridge:8080
+      - BRIDGE_ISSUER_URL=http://localhost:8080
       - BRIDGE_SIGNING_KEY_PATH=/keys/signing-key.pem
       - BRIDGE_USERS
       - BRIDGE_CLIENTS
@@ -38,6 +38,8 @@ services:
     restart: always
     networks:
       - cyphrnet
+    extra_hosts:
+      - "localhost:host-gateway"
     volumes:
       - ./forgejo:/data
       - /etc/localtime:/etc/localtime:ro
@@ -76,7 +78,7 @@ services:
           --provider "openidConnect" \
           --key "forgejo" \
           --secret "forgejo-secret" \
-          --auto-discover-url "http://cyphr-bridge:8080/.well-known/openid-configuration" \
+          --auto-discover-url "http://localhost:8080/.well-known/openid-configuration" \
           --scopes openid \
           --scopes email \
           --scopes profile || echo "CyphrMask auth source already exists or registration failed"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - BRIDGE_PORT=8080
       - BRIDGE_ISSUER_URL=http://localhost:8080
       - BRIDGE_SIGNING_KEY_PATH=/keys/signing-key.pem
-      # - BRIDGE_USERS={"thumbprint":{"email":"user@example.com","public_key":"..."}}
-      # - BRIDGE_CLIENTS=[{"id":"forgejo","secret":"forgejo-secret","redirect_uris":["https://forgejo.example/user/oauth2/Cyphr/callback"]}]
+      - BRIDGE_USERS
+      - BRIDGE_CLIENTS
     volumes:
       - ./keys:/keys
     ports:
@@ -24,6 +24,66 @@ services:
       - "6379:6379"
     networks:
       - cyphrnet
+
+  forgejo:
+    image: codeberg.org/forgejo/forgejo:14
+    container_name: forgejo
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+      - FORGEJO__database__DB_TYPE=sqlite3
+      - FORGEJO__server__ROOT_URL=http://localhost:3000
+      - FORGEJO__security__INSTALL_LOCK=true
+      - FORGEJO__oauth2_client__USERNAME=email
+    restart: always
+    networks:
+      - cyphrnet
+    volumes:
+      - ./forgejo:/data
+      - /etc/localtime:/etc/localtime:ro
+    ports:
+      - "3000:3000"
+      - "222:22"
+    depends_on:
+      bridge:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+
+  forgejo-init:
+    image: codeberg.org/forgejo/forgejo:14
+    container_name: forgejo-init
+    depends_on:
+      forgejo:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "Creating admin user..."
+        forgejo admin user create \
+          --username admin \
+          --password admin123 \
+          --email admin@localhost \
+          --admin \
+          --must-change-password=false 2>/dev/null || echo "Admin user already exists"
+        echo "Registering CyphrMask OIDC auth source..."
+        forgejo admin auth add-oauth \
+          --name "CyphrMask" \
+          --provider "openidConnect" \
+          --key "forgejo" \
+          --secret "forgejo-secret" \
+          --auto-discover-url "http://cyphr-bridge:8080/.well-known/openid-configuration" \
+          --scopes openid \
+          --scopes email \
+          --scopes profile 2>/dev/null || echo "CyphrMask auth source already exists"
+        echo "Forgejo initialization complete."
+    networks:
+      - cyphrnet
+    volumes:
+      - ./forgejo:/data
 
 networks:
   cyphrnet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: cyphr-bridge
     environment:
       - BRIDGE_PORT=8080
-      - BRIDGE_ISSUER_URL=http://localhost:8080
+      - BRIDGE_ISSUER_URL=http://cyphr-bridge:8080
       - BRIDGE_SIGNING_KEY_PATH=/keys/signing-key.pem
       - BRIDGE_USERS
       - BRIDGE_CLIENTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
           --password admin123 \
           --email admin@localhost \
           --admin \
-          --must-change-password=false 2>/dev/null || echo "Admin user already exists"
+          --must-change-password=false || echo "Admin user already exists or creation failed"
         echo "Registering CyphrMask OIDC auth source..."
         forgejo admin auth add-oauth \
           --name "CyphrMask" \
@@ -78,7 +78,7 @@ services:
           --auto-discover-url "http://cyphr-bridge:8080/.well-known/openid-configuration" \
           --scopes openid \
           --scopes email \
-          --scopes profile 2>/dev/null || echo "CyphrMask auth source already exists"
+          --scopes profile || echo "CyphrMask auth source already exists or registration failed"
         echo "Forgejo initialization complete."
     networks:
       - cyphrnet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
       context: ./bridge
       dockerfile: Dockerfile
     container_name: cyphr-bridge
+    network_mode: host
     environment:
       - BRIDGE_PORT=8080
       - BRIDGE_ISSUER_URL=http://localhost:8080
@@ -12,10 +13,6 @@ services:
       - BRIDGE_CLIENTS
     volumes:
       - ./keys:/keys
-    ports:
-      - "8080:8080"
-    networks:
-      - cyphrnet
 
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
**`just up` now spins up a fully configured Forgejo instance** that authenticates
via CyphrMask — no manual UI clicks, no external database. The Forgejo container
starts with SQLite, an admin user (`admin`/`admin123`), and the CyphrMask OIDC
auth source pre-registered via `forgejo admin auth add-oauth`.

The subject (`sub`) claim in issued JWTs is now the key thumbprint instead of the
email address. *This means Forgejo's external user lookup is stable even if a user
changes their email* — previously they'd get a fresh account on every email change.
The email is threaded through the token pipeline (`AuthRequest → Token → userinfo`)
so Forgejo still gets the correct `email`, `email_verified`, `preferred_username`,
and `name` claims.

### What changed

**Bridge claims**: `CompleteAuthRequest` now accepts `(id, subject, email)` instead
of `(id, userID)`. The `findEmailBySubject` helper eliminates duplicated O(n) scans
across `SetUserinfoFromScopes` and `GetPrivateClaimsFromScopes`.

**Forgejo services**: `docker-compose.yml` gains `forgejo` (SQLite, port 3000) and
`forgejo-init` (one-shot init container that runs after the healthcheck passes).
Both mount the shared `./forgejo:/data` volume so the init script operates on the
live database.

**Bridge env**: `BRIDGE_CLIENTS` in `.env` now includes the Forgejo client config
with the correct redirect URI (`/user/oauth2/cyphrmask/callback`).

### Try it

```sh
just up
# Open http://localhost:3000/user/login → "Sign in with CyphrMask"
```