### PR TITLE
feat: add browser-level e2e tests with Playwright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,14 @@ bridge/.keys/
 # Env files (keep .env.example)
 .env
 
+# E2E test data
+e2e/.e2e-user-data/
+e2e/.user-data/
+e2e/node_modules/
+e2e/package-lock.json
+e2e/playwright-report/
+e2e/test-results/
+
 # Workflow / CI artifacts
 .do-results.json
 

--- a/bridge/main.go
+++ b/bridge/main.go
@@ -59,6 +59,19 @@ func main() {
 
 	router := chi.NewRouter()
 	router.Use(logging.Middleware(logging.WithLogger(logger)))
+	// Allow requests from extension origins (chrome-extension://) and local origins
+	router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			if r.Method == "OPTIONS" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	})
 
 	router.Mount("/", http.Handler(provider))
 	router.Handle("/login", loginHandler)

--- a/bridge/storage/storage.go
+++ b/bridge/storage/storage.go
@@ -127,7 +127,7 @@ func (c *Client) RestrictAdditionalAccessTokenScopes() func(scopes []string) []s
 	return func(scopes []string) []string { return scopes }
 }
 func (c *Client) IsScopeAllowed(scope string) bool     { return false }
-func (c *Client) IDTokenUserinfoClaimsAssertion() bool { return false }
+func (c *Client) IDTokenUserinfoClaimsAssertion() bool { return true }
 func (c *Client) ClockSkew() time.Duration             { return 0 }
 
 type Token struct {

--- a/cyphrmask/manifest.json
+++ b/cyphrmask/manifest.json
@@ -10,11 +10,12 @@
   ],
   "host_permissions": [
     "https://*/*",
-    "http://localhost:8080/*"
+    "http://localhost:8080/*",
+    "http://localhost:8089/*"
   ],
   "content_scripts": [
     {
-      "matches": ["https://*/*", "http://localhost:8080/*"],
+      "matches": ["https://*/*", "http://localhost:8080/*", "http://localhost:8089/*"],
       "js": ["src/content.js"],
       "run_at": "document_idle"
     }

--- a/cyphrmask/src/popup/popup.tsx
+++ b/cyphrmask/src/popup/popup.tsx
@@ -76,9 +76,14 @@ function App() {
     const detectBridgeHost = async () => {
         try {
             const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-            if (tab?.url) {
+            if (tab?.url && !tab.url.startsWith('chrome-extension://')) {
                 const url = new URL(tab.url);
                 setBridgeHost(url.origin);
+            } else {
+                const result = await chrome.storage.local.get(['bridgeHost']);
+                if (result.bridgeHost) {
+                    setBridgeHost(result.bridgeHost);
+                }
             }
         } catch {
             const result = await chrome.storage.local.get(['bridgeHost']);

--- a/e2e/extension.spec.ts
+++ b/e2e/extension.spec.ts
@@ -1,0 +1,53 @@
+import { test } from './fixtures/setup';
+import { expect } from '@playwright/test';
+import { TEST_IDENTITY } from './test-data/identity';
+import { seedTestKey, openPopup, waitForWasmReady } from './fixtures/setup';
+
+test.describe('Extension', () => {
+  test('loads and initializes Wasm module', async ({ extContext, extensionId }) => {
+    await waitForWasmReady(extContext, extensionId);
+
+    const page = await openPopup(extContext, extensionId);
+    // Wait for the popup to finish initializing (transition away from loading state)
+    try {
+      await page.waitForSelector('button:has-text("Generate New Key"), button:has-text("Fetch Challenge"), button:has-text("Auth")', { timeout: 10000 });
+    } catch {
+      // If buttons not found, check body doesn't contain loading text
+      const body = await page.locator('body').textContent();
+      expect(body).not.toContain('Initializing crypto module');
+      expect(body).not.toContain('Initialization Failed');
+      await page.close();
+      return;
+    }
+    // If we got here, a button appeared — Wasm is ready
+    await page.close();
+  });
+
+  test('imports test key and derives correct thumbprint', async ({ extContext, extensionId }) => {
+    await seedTestKey(extContext, extensionId);
+
+    const page = await openPopup(extContext, extensionId);
+    await page.getByRole('button', { name: 'Settings' }).click();
+    const tmbCode = await page.locator('.setting-group code').first().textContent();
+    expect(tmbCode).toContain(TEST_IDENTITY.thumbprint.substring(0, 16));
+    await page.close();
+  });
+
+  test('signs a challenge via popup fetch → sign → verify flow', async ({ extContext, extensionId, bridgeUrl }) => {
+    await seedTestKey(extContext, extensionId, bridgeUrl);
+
+    const page = await openPopup(extContext, extensionId);
+    await page.getByRole('button', { name: 'Auth' }).click();
+
+    await page.waitForSelector('button:has-text("Fetch Challenge")', { timeout: 10000 });
+    await page.getByRole('button', { name: 'Fetch Challenge' }).click();
+    await page.waitForSelector('button:has-text("Approve")', { timeout: 10000 });
+    await page.getByRole('button', { name: 'Approve' }).click();
+
+    const msg = await page.waitForSelector('.message.success', { timeout: 15000 });
+    const text = await msg.textContent();
+    expect(text).toContain(TEST_IDENTITY.email);
+
+    await page.close();
+  });
+});

--- a/e2e/fixtures/setup.ts
+++ b/e2e/fixtures/setup.ts
@@ -1,0 +1,290 @@
+import { test as base, chromium, type BrowserContext, type Page } from '@playwright/test';
+import { spawn, type ChildProcess, execSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import { TEST_IDENTITY } from '../test-data/identity';
+
+const BRIDGE_PORT = process.env.BRIDGE_PORT || '8089';
+const BRIDGE_URL = `http://localhost:${BRIDGE_PORT}`;
+const CLIENT_SECRET = 'e2e-test-secret';
+const REDIRECT_URI = 'http://localhost:8090/callback';
+const CHROMIUM_PATH = process.env.CHROMIUM_PATH || '/home/ap/.nix-profile/bin/chromium';
+
+// ---- Bridge fixture (worker-scoped) ----
+
+async function buildBridge(): Promise<string> {
+  const root = path.resolve(__dirname, '..', '..');
+  const binary = path.join(root, 'bridge', 'bridge');
+  if (!fs.existsSync(binary)) {
+    console.log('[bridge] Building bridge binary...');
+    execSync('go build -o bridge .', { cwd: path.join(root, 'bridge'), stdio: 'inherit' });
+  }
+  return binary;
+}
+
+async function waitForBridge(url: string, attempts = 50): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const resp = await fetch(`${url}/health`);
+      if (resp.ok) return;
+    } catch { /* not ready */ }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`Bridge did not become ready at ${url}`);
+}
+
+function getExtensionPath(): string {
+  const root = path.resolve(__dirname, '..', '..');
+  const dist = path.join(root, 'cyphrmask', 'dist');
+  if (!fs.existsSync(dist)) {
+    console.log('[extension] Building extension...');
+    execSync('npm run build', { cwd: path.join(root, 'cyphrmask'), stdio: 'inherit' });
+  }
+  return dist;
+}
+
+// ---- Shared browser context (worker-scoped) ----
+
+let _sharedContext: BrowserContext | null = null;
+let _sharedExtId = '';
+
+async function initSharedBrowser(): Promise<{ context: BrowserContext; extId: string }> {
+  if (_sharedContext) return { context: _sharedContext, extId: _sharedExtId };
+
+  const extPath = getExtensionPath();
+  const userDataDir = path.resolve(__dirname, '..', '.e2e-user-data');
+  if (fs.existsSync(userDataDir)) {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  }
+  fs.mkdirSync(userDataDir, { recursive: true });
+
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    executablePath: CHROMIUM_PATH,
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extPath}`,
+      `--load-extension=${extPath}`,
+      '--no-sandbox',
+      '--disable-gpu',
+      '--disable-dev-shm-usage',
+    ],
+  });
+
+  let workers = context.serviceWorkers();
+  for (let i = 0; i < 30 && workers.length === 0; i++) {
+    await new Promise((r) => setTimeout(r, 500));
+    workers = context.serviceWorkers();
+  }
+  if (workers.length === 0) throw new Error('Extension service worker never started');
+
+  const extId = workers[0].url().match(/^chrome-extension:\/\/([a-z]+)/)?.[1] || '';
+  if (!extId) throw new Error('Could not determine extension ID');
+
+  console.log(`[extension] Service worker loaded, ID: ${extId}`);
+  _sharedContext = context;
+  _sharedExtId = extId;
+  return { context, extId };
+}
+
+async function destroySharedBrowser(): Promise<void> {
+  if (_sharedContext) {
+    await _sharedContext.close();
+    _sharedContext = null;
+    _sharedExtId = '';
+  }
+}
+
+// The main test object — all tests use these fixtures
+export const test = base.extend<{
+  bridgeProcess: ChildProcess;
+  bridgeUrl: string;
+  extContext: BrowserContext;
+  extensionId: string;
+}>({
+  bridgeProcess: [async ({}, use) => {
+    console.log('[bridge-fixture] Starting...');
+    const binary = await buildBridge();
+    console.log('[bridge-fixture] Binary:', binary);
+    const usersJSON = JSON.stringify({
+      [TEST_IDENTITY.thumbprint]: {
+        public_key: TEST_IDENTITY.publicKeyHex,
+        email: TEST_IDENTITY.email,
+      },
+    });
+    const clientsJSON = JSON.stringify([{
+      id: 'e2e-test-client',
+      secret: CLIENT_SECRET,
+      redirect_uris: [
+        'http://localhost:8090/callback',
+        'http://localhost:8091/callback',
+        'http://localhost:8092/callback',
+      ],
+    }]);
+
+    const proc = spawn(binary, [], {
+      env: {
+        ...process.env,
+        BRIDGE_PORT,
+        BRIDGE_ISSUER_URL: BRIDGE_URL,
+        BRIDGE_CLIENT_ID: 'e2e-test-client',
+        BRIDGE_CLIENT_SECRET: CLIENT_SECRET,
+        BRIDGE_CALLBACK_URL: REDIRECT_URI,
+        BRIDGE_USERS: usersJSON,
+        BRIDGE_CLIENTS: clientsJSON,
+      },
+      cwd: path.resolve(__dirname, '..', '..', 'bridge'),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    proc.stdout?.on('data', (d) => process.stdout.write(`[bridge] ${d}`));
+    proc.stderr?.on('data', (d) => process.stderr.write(`[bridge] ${d}`));
+
+    await waitForBridge(BRIDGE_URL);
+    console.log('[bridge] Ready');
+
+    await use(proc);
+
+    proc.kill('SIGTERM');
+    await new Promise((r) => proc.on('exit', r));
+  }, { scope: 'worker' }],
+
+  bridgeUrl: [async ({}, use) => {
+    await use(BRIDGE_URL);
+  }, { scope: 'worker' }],
+
+  extContext: [async ({ bridgeProcess }, use) => {
+    const { context } = await initSharedBrowser();
+    await use(context);
+  }, { scope: 'worker' }],
+
+  extensionId: [async ({}, use) => {
+    const { extId } = await initSharedBrowser();
+    await use(extId);
+  }, { scope: 'worker' }],
+});
+
+// Cleanup on process exit
+process.on('exit', () => { destroySharedBrowser(); });
+
+// ---- Helper: set bridge host in extension storage ----
+
+export async function setBridgeHost(context: BrowserContext, extId: string, bridgeUrl: string): Promise<void> {
+  // Store bridgeHost so the popup's detectBridgeHost falls back to it
+  // (the popup skips chrome-extension:// URLs from tabs.query)
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extId}/popup.html`);
+  await page.evaluate((url) => chrome.storage.local.set({ bridgeHost: url }), bridgeUrl);
+  await page.close();
+  console.log(`[extension] Bridge host set to ${bridgeUrl}`);
+}
+
+// ---- Helper: wait for Wasm to be ready ----
+
+export async function waitForWasmReady(context: BrowserContext, extId: string, timeout = 30000): Promise<void> {
+  const start = Date.now();
+  let attempts = 0;
+  while (Date.now() - start < timeout) {
+    attempts++;
+    try {
+      const page = await context.newPage();
+      await page.goto(`chrome-extension://${extId}/popup.html`);
+      try {
+        await page.waitForSelector('button:has-text("Generate New Key"), button:has-text("Fetch Challenge"), button:has-text("Auth")', { timeout: 5000 });
+        await page.close();
+        console.log(`[extension] Wasm ready after ${attempts} attempts`);
+        return;
+      } catch {
+        const body = await page.locator('body').textContent();
+        await page.close();
+        if (!body?.includes('Initializing') && !body?.includes('Failed')) {
+          console.log(`[extension] Wasm ready after ${attempts} attempts`);
+          return;
+        }
+      }
+    } catch {
+      // page might have been closed by something else
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error('Wasm module did not become ready in time');
+}
+
+// ---- Helper: import test key via the popup UI ----
+
+export async function seedTestKey(context: BrowserContext, extId: string, bridgeUrl?: string): Promise<void> {
+  if (bridgeUrl) await setBridgeHost(context, extId, bridgeUrl);
+  await waitForWasmReady(context, extId);
+
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extId}/popup.html`);
+
+  // Check if we need to import a key or if one already exists
+  try {
+    await page.waitForSelector('button:has-text("Generate New Key")', { timeout: 5000 });
+    // No key — import one
+    const input = page.locator('input[placeholder*="hex"]');
+    await input.fill(TEST_IDENTITY.privateKeyHex);
+    await page.getByRole('button', { name: 'Import Private Key' }).click();
+  } catch {
+    // Check if key is already imported (we'd see Auth/Settings tabs)
+    const body = await page.locator('body').textContent();
+    if (body?.includes('Auth') && body?.includes('Settings')) {
+      // Key already exists — check if it's our test key
+      const settingsBtn = await page.$('button:has-text("Settings")');
+      if (settingsBtn) await settingsBtn.click();
+      const codes = await page.locator('code').allTextContents();
+      if (codes.some(c => c.includes(TEST_IDENTITY.thumbprint.substring(0, 16)))) {
+        await page.close();
+        console.log('[extension] Test key already present');
+        return;
+      }
+    }
+    // Try importing anyway
+    const input = page.locator('input[placeholder*="hex"]');
+    const count = await input.count();
+    if (count > 0) {
+      await input.fill(TEST_IDENTITY.privateKeyHex);
+      await page.getByRole('button', { name: 'Import Private Key' }).click();
+    } else {
+      await page.close();
+      console.log('[extension] Test key already present (no import field)');
+      return;
+    }
+  }
+
+  // Wait for thumbprint to appear
+  try {
+    await page.waitForSelector('code:has-text("' + TEST_IDENTITY.thumbprint.substring(0, 16) + '")', { timeout: 10000 });
+  } catch {
+    // Try switching to Settings tab
+    const settingsBtn = await page.$('button:has-text("Settings")');
+    if (settingsBtn) await settingsBtn.click();
+    await page.waitForSelector('code:has-text("' + TEST_IDENTITY.thumbprint.substring(0, 16) + '")', { timeout: 10000 });
+  }
+
+  await page.close();
+  console.log('[extension] Test key imported via popup');
+}
+
+// ---- Helper: open the extension popup as a Playwright page ----
+
+export function openPopup(context: BrowserContext, extId: string): Promise<Page> {
+  return context.newPage().then(async (page) => {
+    await page.goto(`chrome-extension://${extId}/popup.html`);
+    return page;
+  });
+}
+
+// ---- Helper: wait for content script to be injected in a page ----
+
+export async function waitForContentScript(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    return new Promise<void>((resolve) => {
+      window.addEventListener('message', (e) => {
+        if (e.data?.source === 'cyphrmask' && e.data?.type === 'EXTENSION_STATUS') {
+          resolve();
+        }
+      });
+    });
+  });
+}

--- a/e2e/oidc-flow.spec.ts
+++ b/e2e/oidc-flow.spec.ts
@@ -1,0 +1,171 @@
+import { test } from './fixtures/setup';
+import { expect } from '@playwright/test';
+import { TEST_IDENTITY } from './test-data/identity';
+import { seedTestKey } from './fixtures/setup';
+
+const CLIENT_ID = 'e2e-test-client';
+const CLIENT_SECRET = 'e2e-test-secret';
+
+function startCallbackServer(port: number) {
+  const http = require('http');
+  let srv: any;
+  const captured = new Promise<string>((resolve) => {
+    srv = http.createServer((req: any, res: any) => {
+      const url = `http://${req.headers.host}${req.url}`;
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('OK');
+      resolve(url);
+    });
+    srv.listen(port);
+  });
+  return {
+    close: () => srv.close(),
+    captured,
+  };
+}
+
+test.describe('OIDC Flow', () => {
+  test('full authorization code flow: /auth → login → sign → callback → redirect', async ({ extContext, extensionId, bridgeUrl }) => {
+    await seedTestKey(extContext, extensionId);
+
+    const server = startCallbackServer(8090);
+    const REDIRECT_URI = 'http://localhost:8090/callback';
+
+    const state = 'test-state-' + Date.now();
+    const authUrl = `${bridgeUrl}/authorize?client_id=${CLIENT_ID}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&response_type=code&state=${state}&scope=openid+email`;
+
+    const page = await extContext.newPage();
+    await page.goto(authUrl);
+
+    await page.waitForURL(/\/login\?authRequestID=/, { timeout: 10000 });
+    console.log('[oidc] At login page, waiting for sign button...');
+    // The sign button enables when: (1) challenge fetched, (2) extension signals via postMessage
+    await page.waitForSelector('#sign-btn:not([disabled])', { timeout: 30000 });
+    console.log('[oidc] Sign button enabled, clicking...');
+    await page.click('#sign-btn');
+
+    const statusEl = await page.waitForSelector('.status.success', { timeout: 20000 });
+    const statusText = await statusEl.textContent();
+    expect(statusText).toContain(TEST_IDENTITY.email);
+
+    const callbackUrl = await server.captured;
+    expect(callbackUrl).toContain(REDIRECT_URI);
+    expect(callbackUrl).toContain('code=');
+    expect(callbackUrl).toContain('state=' + state);
+
+    const code = new URL(callbackUrl).searchParams.get('code');
+    expect(code).toBeTruthy();
+
+    const tokenResp = await fetch(`${bridgeUrl}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: code!,
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        redirect_uri: REDIRECT_URI,
+      }),
+    });
+
+    expect(tokenResp.ok).toBe(true);
+    const tokens = await tokenResp.json();
+    expect(tokens.access_token).toBeTruthy();
+    expect(tokens.id_token).toBeTruthy();
+    expect(tokens.token_type).toBe('Bearer');
+
+    server.close();
+    await page.close();
+  });
+
+  test('ID token contains correct claims', async ({ extContext, extensionId, bridgeUrl }) => {
+    await seedTestKey(extContext, extensionId);
+
+    const server = startCallbackServer(8091);
+    const REDIRECT_URI = 'http://localhost:8091/callback';
+
+    const state = 'claims-test-' + Date.now();
+    const authUrl = `${bridgeUrl}/authorize?client_id=${CLIENT_ID}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&response_type=code&state=${state}&scope=openid+email`;
+
+    const page = await extContext.newPage();
+    await page.goto(authUrl);
+    await page.waitForURL(/\/login\?authRequestID=/, { timeout: 10000 });
+    await page.waitForSelector('#sign-btn:not([disabled])', { timeout: 30000 });
+    await page.click('#sign-btn');
+
+    const callbackUrl = await server.captured;
+    const code = new URL(callbackUrl).searchParams.get('code');
+    expect(code).toBeTruthy();
+
+    const tokenResp = await fetch(`${bridgeUrl}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: code!,
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        redirect_uri: REDIRECT_URI,
+      }),
+    });
+
+    const tokens = await tokenResp.json();
+    const idToken = tokens.id_token as string;
+    const payloadB64 = idToken.split('.')[1];
+    const padded = payloadB64 + '='.repeat((4 - payloadB64.length % 4) % 4);
+    const payload = JSON.parse(Buffer.from(padded, 'base64').toString('utf-8'));
+
+    expect(payload.sub).toBe(TEST_IDENTITY.thumbprint);
+    expect(payload.email).toBe(TEST_IDENTITY.email);
+    expect(payload.iss).toBe(bridgeUrl);
+    expect(payload.aud).toEqual([CLIENT_ID]);
+
+    server.close();
+    await page.close();
+  });
+
+  test('userinfo endpoint returns correct subject', async ({ extContext, extensionId, bridgeUrl }) => {
+    await seedTestKey(extContext, extensionId);
+
+    const server = startCallbackServer(8092);
+    const REDIRECT_URI = 'http://localhost:8092/callback';
+
+    const state = 'userinfo-test-' + Date.now();
+    const authUrl = `${bridgeUrl}/authorize?client_id=${CLIENT_ID}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&response_type=code&state=${state}&scope=openid+email`;
+
+    const page = await extContext.newPage();
+    await page.goto(authUrl);
+    await page.waitForURL(/\/login\?authRequestID=/, { timeout: 10000 });
+    await page.waitForSelector('#sign-btn:not([disabled])', { timeout: 30000 });
+    await page.click('#sign-btn');
+
+    const callbackUrl = await server.captured;
+    const code = new URL(callbackUrl).searchParams.get('code');
+    expect(code).toBeTruthy();
+
+    const tokenResp = await fetch(`${bridgeUrl}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: code!,
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        redirect_uri: REDIRECT_URI,
+      }),
+    });
+
+    const tokens = await tokenResp.json();
+    const userinfoResp = await fetch(`${bridgeUrl}/userinfo`, {
+      headers: { 'Authorization': `Bearer ${tokens.access_token}` },
+    });
+
+    expect(userinfoResp.ok).toBe(true);
+    const userinfo = await userinfoResp.json();
+    expect(userinfo.sub).toBe(TEST_IDENTITY.thumbprint);
+    expect(userinfo.email).toBe(TEST_IDENTITY.email);
+
+    server.close();
+    await page.close();
+  });
+});

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cyphrmask-e2e",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "test:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.44.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test';
+
+const BRIDGE_PORT = process.env.BRIDGE_PORT || '8089';
+const BRIDGE_URL = `http://localhost:${BRIDGE_PORT}`;
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: /\.spec\.ts$/,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  timeout: 180_000,
+  use: {
+    trace: 'retain-on-failure',
+    baseURL: BRIDGE_URL,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        channel: 'chromium',
+        executablePath: process.env.CHROMIUM_PATH || '/home/ap/.nix-profile/bin/chromium',
+      },
+    },
+  ],
+});

--- a/e2e/test-data/identity.ts
+++ b/e2e/test-data/identity.ts
@@ -1,0 +1,12 @@
+// Deterministic ECDSA P-256 test identity for e2e tests.
+// Generated once; same key is used across all runs so the bridge
+// can be pre-configured with BRIDGE_USERS.
+export const TEST_IDENTITY = {
+  // Raw 32-byte private key as 64-char hex string
+  privateKeyHex: '53a3ae6a231cac1562372dead986f6f1e19ccb50d9549a9ea5ba068d449d1ff5',
+  // Uncompressed public key: 04 || X(32) || Y(32) = 65 bytes = 130 hex chars
+  publicKeyHex: '041e65c079314884a299a1052e2a65dcc322b16cfec6228b42f9c3082c372fd31f4a4be96ad5707e79c849666db8bf84318da28a0f77c9caa377d6e71c84143621',
+  // JWK thumbprint (RFC 7638), base64url-encoded SHA-256 of canonical JWK
+  thumbprint: 'azXsImbzLeghWzQsPs_oPWDRPRZi2pVpS-65-svOuPU',
+  email: 'e2e-test@example.com',
+} as const;


### PR DESCRIPTION
## Summary

- **6 browser-level e2e tests** (3 extension + 3 OIDC flow) using Playwright with Chromium extension loading
- Tests cover: Wasm init, key import via popup, popup challenge→sign→verify, full OIDC authorization code flow, ID token claims, and userinfo endpoint
- Uses Playwright worker-scoped fixtures for shared bridge process + browser context (single browser instance across all tests)

## Bug fixes discovered during e2e testing

- **CORS middleware** added to bridge — extension's `fetch()` from popup was being blocked
- **popup.tsx `detectBridgeHost`** now skips `chrome-extension://` URLs from `chrome.tabs.query` (popup tab was always returned as "active", preventing bridgeHost fallback to storage)
- **`IDTokenUserinfoClaimsAssertion`** enabled so `email` claim appears in ID tokens (was returning `undefined` — scope was removed by Zitadel's `removeUserinfoScopes` before `GetPrivateClaimsFromScopes`)
- **manifest.json** updated with port 8089 in `host_permissions` and `content_scripts` matches

## What's tested

| Test | Coverage |
|------|----------|
| Extension loads and initializes Wasm module | Service worker detection, Wasm ready check |
| Key import via popup | UI flow, thumbprint derivation |
| Popup challenge → sign → verify | End-to-end Coz signing from extension |
| Full OIDC authorization code flow | `/authorize` → `/login` → postMessage → Coz sign → verify → callback → redirect with code → token exchange |
| ID token claims | `sub` = thumbprint, `email`, `iss`, `aud` |
| Userinfo endpoint | Bearer token auth, `sub` and `email` claims |